### PR TITLE
use multiline mode in Regexp

### DIFF
--- a/app/models/simple_rss.rb
+++ b/app/models/simple_rss.rb
@@ -139,7 +139,7 @@ class SimpleRss < DynamicContent
     result = []
     begin
       # this will only work with nodesets for now
-      re_pattern = Regexp.new(pattern)
+      re_pattern = Regexp.new(pattern, Regexp::MULTILINE)
       if nodes.is_a?(Array) && nodes.count > 0 && nodes.first.is_a?(REXML::Element)
         nodes.each do |node|
           s = node.to_s


### PR DESCRIPTION
Without it, there is not possibility to replace content that spans multiple lines. If someone still needs single line semantics, he could use the dollar and carret operators.
