### PR TITLE
Handle feeds requiring basic http authentication

### DIFF
--- a/app/assets/javascripts/concerto_simple_rss/simple_rss.js
+++ b/app/assets/javascripts/concerto_simple_rss/simple_rss.js
@@ -12,6 +12,8 @@ function previewSimpleRss() {
   var url = $('input#simple_rss_config_url').data('url');
   if (url) {
     rss_url = $('input#simple_rss_config_url').val();
+    userid = $('input#simple_rss_config_url_userid').val();
+    password = $('input#simple_rss_config_url_password').val();
     output_format = $('select#simple_rss_config_output_format').val();
     max_items = $('input#simple_rss_config_max_items').val();
     reverse_order = $('select#simple_rss_config_reverse_order').val();
@@ -22,6 +24,8 @@ function previewSimpleRss() {
     }
     $("#preview_div").load(url, { data: { 
       url: rss_url, 
+      url_userid: userid,
+      url_password: password,
       output_format: output_format, 
       max_items: max_items,
       reverse_order: reverse_order,
@@ -40,6 +44,8 @@ function initializeSimpleRssHandlers() {
     // on blur and change of url, display format, reverse_order, max items, and xsl
     // not on keyup (poor man's debouncing technique?)
     $('input#simple_rss_config_url').on('blur', previewSimpleRss);
+    $('input#simple_rss_config_url_userid').on('blur', previewSimpleRss);
+    $('input#simple_rss_config_url_password').on('blur', previewSimpleRss);
     $('select#simple_rss_config_output_format').on('change', previewSimpleRss);
     $('input#simple_rss_config_max_items').on('blur', previewSimpleRss);
     $('select#simple_rss_config_reverse_order').on('change', previewSimpleRss);

--- a/app/models/simple_rss.rb
+++ b/app/models/simple_rss.rb
@@ -1,4 +1,5 @@
 class SimpleRss < DynamicContent
+  require 'base64'
 
   DISPLAY_NAME = 'RSS Feed'
 
@@ -9,167 +10,167 @@ class SimpleRss < DynamicContent
   # Called during `after_find`.
   def load_config
     j = JSON.load(self.data)
+    
     # decrypt fields
-Rails.logger.debug("--------------------------- rss decrypting ")
+    unless j.blank?
+      encrypted_userid = Base64.decode64(j['url_userid_enc']) unless j['url_userid_enc'].blank?
+      encrypted_password = Base64.decode64(j['url_password_enc']) unless j['url_password_enc'].blank?
 
-    j[:url_userid] = (j[:url_userid_enc].blank? ? "" : j[:url_userid_enc].decrypt)
-    j[:url_password] = (j[:url_password_enc].blank? ? "" : j[:url_password_enc].decrypt)
-    j.delete :url_userid_enc
-    j.delete :url_password_enc
+      j['url_userid'] = (encrypted_userid.blank? ? "" : encrypted_userid.decrypt)
+      j['url_password'] = (encrypted_password.blank? ? "" : encrypted_password.decrypt)
+    end 
 
     self.config = j
-Rails.logger.debug("--------------------------- rss decrypting done")
   end
 
   # Prepare the configuration to be saved.
   # Compress the config hash back into JSON to be stored in the database.
   # Called during `before_validation`.
   def save_config
-    j = JSON.load(JSON.dump(self.config))
+    j = self.config.deep_dup
+
     # encrypt fields
-Rails.logger.debug("--------------------------- rss encrypting ")
-
-    j[:url_userid_enc] = (j[:url_userid].blank? ? "" : j[:url_userid].encrypt)
-    j[:url_password_enc] = (j[:url_password].blank? ? "" : j[:url_password].encrypt)
-    j.delete :url_userid
-    j.delete :url_password
-
+    j['url_userid_enc'] = (j['url_userid'].blank? ? "" : Base64.encode64(j['url_userid'].encrypt))
+    j['url_password_enc'] = (j['url_password'].blank? ? "" : Base64.encode64(j['url_password'].encrypt))
+    j.delete 'url_userid'
+    j.delete 'url_password'
     self.data = JSON.dump(j)
-Rails.logger.debug("--------------------------- rss encrypting done")
   end
 
   def build_content
     contents = []
 
     url = self.config['url']
-    url_userid = self.config['url_userid']
-    url_password = self.config['url_password']
-    type, feed_title, rss, raw = fetch_feed(url, url_userid, url_password)
-    
-    if (["RSS", "ATOM"].include? type) && !feed_title.blank?
-      # it is a valid feed
-      if !self.config['reverse_order'].blank? && self.config['reverse_order'] == '1'
-        rss.items.reverse!
-      end
-      feed_items = rss.items
-      if !self.config['max_items'].blank? && self.config['max_items'].to_i > 0
-        feed_items = feed_items.first(self.config['max_items'].to_i)
-      end
-      case self.config['output_format']
-      when 'headlines'
-        feed_items.each_slice(5).with_index do |items, index|
-          htmltext = HtmlText.new()
-          htmltext.name = "#{feed_title} (#{index+1})"
-          htmltext.data = sanitize("<h1>#{feed_title}</h1> #{items_to_html(items, type)}")
-          contents << htmltext
+    unless url.blank?
+      url_userid = self.config['url_userid']
+      url_password = self.config['url_password']
+      type, feed_title, rss, raw = fetch_feed(url, url_userid, url_password)
+      
+      if (["RSS", "ATOM"].include? type) && !feed_title.blank?
+        # it is a valid feed
+        if !self.config['reverse_order'].blank? && self.config['reverse_order'] == '1'
+          rss.items.reverse!
         end
-      when 'detailed'
-        feed_items.each_with_index do |item, index|
-          htmltext = HtmlText.new()
-          htmltext.name = "#{feed_title} (#{index+1})"
-          htmltext.data = sanitize(item_to_html(item, type))
-          contents << htmltext
+        feed_items = rss.items
+        if !self.config['max_items'].blank? && self.config['max_items'].to_i > 0
+          feed_items = feed_items.first(self.config['max_items'].to_i)
         end
-      when 'xslt'
-        require 'rexml/document'
-        require 'xml/xslt'
-
-        #XML::XSLT.registerErrorHandler { |string| puts string }
-        xslt = XML::XSLT.new()
-        begin
-          xslt.xml = REXML::Document.new(raw)
-        rescue REXML::ParseException => e
-          Rails.logger.error("Unable to parse incoming feed: #{e.message}")
-          raise "Unable to parse incoming feed. "
-        rescue => e
-          raise e
-        end
-
-        begin
-          xslt.xsl = REXML::Document.new(self.config['xsl'])
-        rescue REXML::ParseException => e
-          Rails.logger.error("Unable to parse Xsl: #{e.message}")
-          # fmt is <rexml::parseexception: message :> trace ... so just pull out the message
-          s = e.message
-          msg_stop = s.index(">")
-          s = s.slice(23, msg_stop - 23) if !msg_stop.nil?
-          raise "Unable to parse Xsl.  #{s}"
-        rescue => e
-          raise e
-        end
-
-        # add a replace [gsub] function for more powerful transforms.  You can use this in a transform
-        # by adding the bogus namespace http://concerto.functions
-        # A nodeset comes in as an array of REXML::Elements 
-        XML::XSLT.registerExtFunc("http://concerto.functions", "replace") do |nodes, pattern, replacement|
-          result = xslt_replace(nodes, pattern, replacement)
-          result
-        end
-
-        XML::XSLT.registerExtFunc("http://schemas.concerto-signage.org/functions", "replace") do |nodes, pattern, replacement|
-          result = xslt_replace(nodes, pattern, replacement)
-          result
-        end
-
-        data = xslt.serve()
-        # xslt.serve does always return a string with ASCII-8BIT encoding regardless of what the actual encoding is
-        data = data.force_encoding(xslt.xml.encoding) if data
-
-        # try to load the transformed data as an xml document so we can see if there are 
-        # mulitple content-items that we need to parse out, if we cant then treat it as one content item
-        begin
-          data_xml = REXML::Document.new('<root>' + data + '</root>')
-          nodes = REXML::XPath.match(data_xml, "//content-item")
-          # if there are no content-items then add the whole result (data) as one content
-          if nodes.count == 0
+        case self.config['output_format']
+        when 'headlines'
+          feed_items.each_slice(5).with_index do |items, index|
             htmltext = HtmlText.new()
-            htmltext.name = "#{feed_title}"
-            htmltext.data = sanitize(data)
+            htmltext.name = "#{feed_title} (#{index+1})"
+            htmltext.data = sanitize("<h1>#{feed_title}</h1> #{items_to_html(items, type)}")
             contents << htmltext
-          else
-            # if there are any content-items then add each one as a separate content
-            # and strip off the content-item wrapper
-            nodes.each do |n|
+          end
+        when 'detailed'
+          feed_items.each_with_index do |item, index|
+            htmltext = HtmlText.new()
+            htmltext.name = "#{feed_title} (#{index+1})"
+            htmltext.data = sanitize(item_to_html(item, type))
+            contents << htmltext
+          end
+        when 'xslt'
+          require 'rexml/document'
+          require 'xml/xslt'
+
+          #XML::XSLT.registerErrorHandler { |string| puts string }
+          xslt = XML::XSLT.new()
+          begin
+            xslt.xml = REXML::Document.new(raw)
+          rescue REXML::ParseException => e
+            Rails.logger.error("Unable to parse incoming feed: #{e.message}")
+            raise "Unable to parse incoming feed. "
+          rescue => e
+            raise e
+          end
+
+          begin
+            xslt.xsl = REXML::Document.new(self.config['xsl'])
+          rescue REXML::ParseException => e
+            Rails.logger.error("Unable to parse Xsl: #{e.message}")
+            # fmt is <rexml::parseexception: message :> trace ... so just pull out the message
+            s = e.message
+            msg_stop = s.index(">")
+            s = s.slice(23, msg_stop - 23) if !msg_stop.nil?
+            raise "Unable to parse Xsl.  #{s}"
+          rescue => e
+            raise e
+          end
+
+          # add a replace [gsub] function for more powerful transforms.  You can use this in a transform
+          # by adding the bogus namespace http://concerto.functions
+          # A nodeset comes in as an array of REXML::Elements 
+          XML::XSLT.registerExtFunc("http://concerto.functions", "replace") do |nodes, pattern, replacement|
+            result = xslt_replace(nodes, pattern, replacement)
+            result
+          end
+
+          XML::XSLT.registerExtFunc("http://schemas.concerto-signage.org/functions", "replace") do |nodes, pattern, replacement|
+            result = xslt_replace(nodes, pattern, replacement)
+            result
+          end
+
+          data = xslt.serve()
+          # xslt.serve does always return a string with ASCII-8BIT encoding regardless of what the actual encoding is
+          data = data.force_encoding(xslt.xml.encoding) if data
+
+          # try to load the transformed data as an xml document so we can see if there are 
+          # mulitple content-items that we need to parse out, if we cant then treat it as one content item
+          begin
+            data_xml = REXML::Document.new('<root>' + data + '</root>')
+            nodes = REXML::XPath.match(data_xml, "//content-item")
+            # if there are no content-items then add the whole result (data) as one content
+            if nodes.count == 0
               htmltext = HtmlText.new()
               htmltext.name = "#{feed_title}"
-              htmltext.data = sanitize(n.to_s.gsub(/^\s*\<content-item\>/, '').gsub(/\<\/content-item\>\s*$/,''))
+              htmltext.data = sanitize(data)
+              contents << htmltext
+            else
+              # if there are any content-items then add each one as a separate content
+              # and strip off the content-item wrapper
+              nodes.each do |n|
+                htmltext = HtmlText.new()
+                htmltext.name = "#{feed_title}"
+                htmltext.data = sanitize(n.to_s.gsub(/^\s*\<content-item\>/, '').gsub(/\<\/content-item\>\s*$/,''))
+                contents << htmltext
+              end
+            end
+          rescue => e
+            # maybe the html was not xml compliant-- this happens frequently in rss feed descriptions
+            # look for another separator and use it, if it exists
+
+            if data.include?("</content-item>")
+              # if there are any content-items then add each one as a separate content
+              # and strip off the content-item wrapper
+              data.split("</content-item>").each do |n|
+                htmltext = HtmlText.new()
+                htmltext.name = "#{feed_title}"
+                htmltext.data = sanitize(n.sub("<content-item>", ""))
+                contents << htmltext if !htmltext.data.strip.blank?
+              end
+
+            else
+              Rails.logger.error("unable to parse resultant xml, assuming it is one content item #{e.message}")
+              # raise "unable to parse resultant xml #{e.message}"
+              # add the whole result as one content
+              htmltext = HtmlText.new()
+              htmltext.name = "#{feed_title}"
+              htmltext.data = sanitize(data)
               contents << htmltext
             end
           end
-        rescue => e
-          # maybe the html was not xml compliant-- this happens frequently in rss feed descriptions
-          # look for another separator and use it, if it exists
-
-          if data.include?("</content-item>")
-            # if there are any content-items then add each one as a separate content
-            # and strip off the content-item wrapper
-            data.split("</content-item>").each do |n|
-              htmltext = HtmlText.new()
-              htmltext.name = "#{feed_title}"
-              htmltext.data = sanitize(n.sub("<content-item>", ""))
-              contents << htmltext if !htmltext.data.strip.blank?
-            end
-
-          else
-            Rails.logger.error("unable to parse resultant xml, assuming it is one content item #{e.message}")
-            # raise "unable to parse resultant xml #{e.message}"
-            # add the whole result as one content
-            htmltext = HtmlText.new()
-            htmltext.name = "#{feed_title}"
-            htmltext.data = sanitize(data)
-            contents << htmltext
-          end
+        else
+          raise ArgumentError, 'Unexpected output format for RSS feed.'
         end
+      elsif type == "ERROR"
+        raise rss
       else
-        raise ArgumentError, 'Unexpected output format for RSS feed.'
+        Rails.logger.error("could not fetch #{type} feed for #{feed_title} at #{url}")
+        raise "Unexpected feed format for #{url}."
       end
-    elsif type == "ERROR"
-      raise rss
-    else
-      Rails.logger.error("could not fetch #{type} feed for #{feed_title} at #{url}")
-      raise "Unexpected feed format for #{url}."
     end
-
+    
     return contents
   end
 
@@ -210,33 +211,35 @@ Rails.logger.debug("--------------------------- rss encrypting done")
     rss = nil
     feed = nil
 
-    begin
-      # cache same url for 1 minute to alleviate redundant calls when previewing
-      feed = Rails.cache.fetch(url, :expires_in => 1.minute) do
-        if url_userid.blank? or url_password.blank?
-          open(url).read()
-        else
-          open(url, http_basic_authentication: [url_userid, url_password]).read()
+    unless url.blank?
+      begin
+        # cache same url for 1 minute to alleviate redundant calls when previewing
+        feed = Rails.cache.fetch(url, :expires_in => 1.minute) do
+          if url_userid.blank? or url_password.blank?
+            open(url).read()
+          else
+            open(url, http_basic_authentication: [url_userid, url_password]).read()
+          end
         end
-      end
 
-      rss = RSS::Parser.parse(feed, false, true)
-      raise "feed could not be parsed" if rss.nil?
-    rescue => e
-      # cant parse rss or url is bad
-      Rails.logger.debug("unable to fetch or parse feed - #{url}, #{e.message}")
-      rss = e.message
-      type = "ERROR"
-    else
-      type = rss.feed_type.upcase
-
-      case type
-      when "RSS"
-        title = rss.channel.title
-      when "ATOM"
-        title = rss.title.content
+        rss = RSS::Parser.parse(feed, false, true)
+        raise "feed could not be parsed" if rss.nil?
+      rescue => e
+        # cant parse rss or url is bad
+        Rails.logger.debug("unable to fetch or parse feed - #{url}, #{e.message}")
+        rss = e.message
+        type = "ERROR"
       else
-        #title = "unknown feed type"
+        type = rss.feed_type.upcase
+
+        case type
+        when "RSS"
+          title = rss.channel.title
+        when "ATOM"
+          title = rss.title.content
+        else
+          #title = "unknown feed type"
+        end
       end
     end
 

--- a/app/views/contents/simple_rss/_form_top.html.erb
+++ b/app/views/contents/simple_rss/_form_top.html.erb
@@ -9,16 +9,20 @@
       </div>
     </div>
 
-    <div class="clearfix">
-      <%= config.label :url_userid %>
-      <div class="input">
-        <%= config.text_field :url_userid, :class => "input-medium" %>
-      </div>
-    </div>
-    <div class="clearfix">
-      <%= config.label :url_password %>
-      <div class="input">
-        <%= config.password_field :url_password, :class => "input-medium" %>
+    <div class="row-fluid">
+      <div class="span6">
+        <div class="clearfix span6">
+          <%= label_tooltip "simple_rss", :url_userid, t("activerecord.attributes.simple_rss.config_url_userid"), tip: t("basic_auth_tip") %>
+          <div class="input">
+            <%= config.text_field :url_userid, :class => "input-medium", autocomplete: :off %>
+          </div>
+        </div>
+        <div class="clearfix span6">
+          <%= config.label :url_password, t("activerecord.attributes.simple_rss.config_url_password") %>
+          <div class="input">
+            <%= config.password_field :url_password, :class => "input-medium", autocomplete: :off %>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/app/views/contents/simple_rss/_form_top.html.erb
+++ b/app/views/contents/simple_rss/_form_top.html.erb
@@ -6,9 +6,22 @@
       <%= config.label :url %>
       <div class="input">
         <%= config.url_field :url, :placeholder => 'http://feeds.bbci.co.uk/news/rss.xml', :class => "input-xxlarge", :value => @content.config['url'], "data-url" => preview_contents_path %>
-        <div><small>You can verify an RSS feed at <a href="http://validator.w3.org/feed/" target="_blank">http://validator.w3.org/feed/</a></small></div>
       </div>
     </div>
+
+    <div class="clearfix">
+      <%= config.label :url_userid %>
+      <div class="input">
+        <%= config.text_field :url_userid, :class => "input-medium" %>
+      </div>
+    </div>
+    <div class="clearfix">
+      <%= config.label :url_password %>
+      <div class="input">
+        <%= config.password_field :url_password, :class => "input-medium" %>
+      </div>
+    </div>
+
     <div class="clearfix">
       <%= config.label :output_format, 'Display Format' %>
       <div class="input">

--- a/concerto_simple_rss.gemspec
+++ b/concerto_simple_rss.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
+  s.add_dependency "encryptor"
   s.add_dependency "ruby-xslt", "~> 0.9"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,7 @@
+en:
+  activerecord:
+    attributes:
+      simple_rss:
+        config_url_userid: "Basic Auth Id"
+        config_url_password: "Password"
+  basic_auth_tip: "Leave the User Id and Password blank if the URL does not require Basic HTTP Authentication."

--- a/lib/concerto_simple_rss/engine.rb
+++ b/lib/concerto_simple_rss/engine.rb
@@ -1,9 +1,13 @@
 module ConcertoSimpleRss
   class Engine < ::Rails::Engine
+    require 'encryptor'
+    
     isolate_namespace ConcertoSimpleRss
 
     initializer "register content type" do |app|
       app.config.content_types << SimpleRss
+
+      Encryptor.default_options.merge!(key: ENV["SECRET_KEY_BASE"])
     end
   end
 end


### PR DESCRIPTION
This uses the encryptor gem and stores only the encrypted credentials in the database.  

I'm unhappy about not being able to turn off the autocomplete/autofill in the form for the user id and password fields, and having to explicitly specify an i18n path/key for those fields label's (they should have been pulled from the attributes).

This closes #45.